### PR TITLE
Fix signup id generation and page props

### DIFF
--- a/src/routes/(auth)/auth/signup/+page.server.ts
+++ b/src/routes/(auth)/auth/signup/+page.server.ts
@@ -43,7 +43,7 @@ export const actions: Actions = {
 
     if (maxError) return fail(500, { message: maxError.message });
 
-    const newId = maxData[0].id + 1;
+    const newId = maxData?.length ? maxData[0].id + 1 : 1;
 
     const { error: upsertError } = await supabase
       .from("profiles")

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -3,7 +3,9 @@
   import { onMount } from "svelte";
 
   const { data } = $props();
-  const { totalCubes, totalUsers, achievements } = $derived(data);
+  const { totalCubes, totalUsers, achievements } = $derived(
+    data || { totalCubes: 0, totalUsers: 0, achievements: [] }
+  );
   let mounted = $state(false);
 
   const unlockAchi = () => {


### PR DESCRIPTION
## Summary
- avoid failing signups when no profiles exist
- make home page component handle missing props during testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68541fc62a40832c9f64b7a5a23a1877